### PR TITLE
Remove redundant checks for channel types

### DIFF
--- a/commands/auto.js
+++ b/commands/auto.js
@@ -3,7 +3,7 @@ const channels = require("../index").channels,
 
 const run = (client, data, respond) => {
     const thread = data.data.resolved.channels[Object.keys(data.data.resolved.channels)[0]]
-    if(![0,5].includes(thread.type)) return respond("❌ Issue", "The attatched channel needs to be a text channel", "#ff0000")
+
     if(channels.has(thread.id)) { 
         try {
             removeThread(thread.id, "channels")

--- a/commands/batch.js
+++ b/commands/batch.js
@@ -36,7 +36,7 @@ const batchInChannel = async (channel, action, pattern = null ) => {
 
 const run = async (client, data, respond) => {
     const parent = data.data.resolved.channels[Object.keys(data.data.resolved.channels)[0]]
-    if([11, 12, 13, 6, 2, 1].includes(parent.type)) return respond("❌ Issue", "that channel type cannot hold threads", "#ff0000")
+
     let [ action, _p, pattern ] = data.data.options.map(o => o.value)
     const pChannel = client.channels.cache.get(_p)
     let blacklist = false

--- a/commands/watch.js
+++ b/commands/watch.js
@@ -3,7 +3,7 @@ const threads = require("../index").threads,
 
 const run = (client, data, respond) => {
     const thread = data.data.resolved.channels[Object.keys(data.data.resolved.channels)[0]]
-    if(![10,11,12].includes(thread.type)) return respond("❌ Issue", "The attatched channel is not a thread.", "#ff0000")
+
     if(threads.has(thread.id)) { 
         try {
             removeThread(thread.id)


### PR DESCRIPTION
Since specifying `channel_types` fields (#17), Discord now enforces correct channel types and therefore Thread-Watcher will no longer get interactions with a wrong type of channel specified, there is no reason to keep checking them.