### PR TITLE
[EMERGENCY] Return after responding with permission error

### DIFF
--- a/commands/auto.js
+++ b/commands/auto.js
@@ -7,6 +7,7 @@ const run = (client, data, respond) => {
   // Manage Channels or Manage Server
   if (permissions & (1 << 4) === (1 << 4) || permissions & (1 << 5) === (1 << 5)) {
     respond('You do not have permission to use /auto command.', 'You need Manage Channels or Manage Server permission to use it.', '#ff0000', true);
+    return;
   }
 
   const thread = data.data.resolved.channels[Object.keys(data.data.resolved.channels)[0]];
@@ -30,6 +31,6 @@ const run = (client, data, respond) => {
       respond('❌ Issue', 'Bot failed to add channel to watchlist. Sorry about that', '#ff0000', true);
     }
   }
-}
+};
 
 module.exports = { run };

--- a/commands/batch.js
+++ b/commands/batch.js
@@ -47,10 +47,10 @@ const batchInChannel = async (channel, action, pattern = null ) => {
           removeThread(id);
         }
 
-        rv.succeeded++
+        rv.succeeded++;
       }
       catch(err) {
-        rv.failed++
+        rv.failed++;
       }
     });
 
@@ -64,6 +64,7 @@ const run = async (client, data, respond) => {
   // Manage Channels or Manage Server
   if (permissions & (1 << 4) === (1 << 4) || permissions & (1 << 5) === (1 << 5)) {
     respond('You do not have permission to use /batch command.', 'You need Manage Channels or Manage Server permission to use it.', '#ff0000', true);
+    return;
   }
 
   const parent = data.data.resolved.channels[Object.keys(data.data.resolved.channels)[0]];
@@ -92,7 +93,7 @@ const run = async (client, data, respond) => {
     failed: 0
   };
 
-  if (pChannel.type == 'GUILD_CATEGORY') {
+  if (pChannel.type === 'GUILD_CATEGORY') {
     for (let [key, child] of pChannel.children) {
       const a = await batchInChannel(child, action, [ pattern, blacklist ]);
       actions.succeeded += a.succeeded;

--- a/commands/watch.js
+++ b/commands/watch.js
@@ -7,6 +7,7 @@ const run = (client, data, respond) => {
   // Manage Channels or Manage Server
   if (permissions & (1 << 4) === (1 << 4) || permissions & (1 << 5) === (1 << 5)) {
     respond('You do not have permission to use /watch command.', 'You need Manage Channels or Manage Server permission to use it.', '#ff0000', true);
+    return;
   }
 
   const thread = data.data.resolved.channels[Object.keys(data.data.resolved.channels)[0]];


### PR DESCRIPTION
I made a very huge mistake in #21 which would allow continuing processing after responding with permission error.
This pull request will fix it by returning after responding with it.
I am terribly sorry. I will review my code carefully in the future.
