### PR TITLE
Require Manage Threads permission instead

### DIFF
--- a/commands/auto.js
+++ b/commands/auto.js
@@ -1,12 +1,12 @@
 const channels = require('../index').channels,
-  { addThread, removeThread } = require('./utils/threadActions');
+  { addThread, removeThread } = require('./utils/threadActions'),
+  { Permissions } = require('discord.js');
 
 const run = (client, data, respond) => {
-  const permissions = data.member.permissions;
+  const user_permissions = new Permissions(BigInt(data.member.permissions));
 
-  // Manage Channels or Manage Server
-  if (!((permissions & (1 << 4)) === (1 << 4) || (permissions & (1 << 5)) === (1 << 5))) {
-    respond('You do not have permission to use /auto command.', 'You need Manage Channels or Manage Server permission to use it.', '#ff0000', true);
+  if (!user_permissions.has(Permissions.FLAGS.MANAGE_THREADS)) {
+    respond('You do not have permission to use /auto command.', 'You need Manage Threads permission to use it.', '#ff0000', true);
     return;
   }
 

--- a/commands/batch.js
+++ b/commands/batch.js
@@ -1,5 +1,6 @@
 const { threads } = require('../index'),
-  { addThread, removeThread } = require('./utils/threadActions');
+  { addThread, removeThread } = require('./utils/threadActions'),
+  { Permissions } = require('discord.js');
 
 /**
  * 
@@ -59,11 +60,10 @@ const batchInChannel = async (channel, action, pattern = null ) => {
 };
 
 const run = async (client, data, respond) => {
-  const permissions = data.member.permissions;
+  const user_permissions = new Permissions(BigInt(data.member.permissions));
 
-  // Manage Channels or Manage Server
-  if (!((permissions & (1 << 4)) === (1 << 4) || (permissions & (1 << 5)) === (1 << 5))) {
-    respond('You do not have permission to use /batch command.', 'You need Manage Channels or Manage Server permission to use it.', '#ff0000', true);
+  if (!user_permissions.has(Permissions.FLAGS.MANAGE_THREADS)) {
+    respond('You do not have permission to use /batch command.', 'You need Manage Threads permission to use it.', '#ff0000', true);
     return;
   }
 

--- a/commands/watch.js
+++ b/commands/watch.js
@@ -1,12 +1,12 @@
 const threads = require('../index').threads,
-  { addThread, removeThread } = require('./utils/threadActions');
+  { addThread, removeThread } = require('./utils/threadActions'),
+  { Permissions } = require('discord.js');
 
 const run = (client, data, respond) => {
-  const permissions = data.member.permissions;
+  const user_permissions = new Permissions(BigInt(data.member.permissions));
 
-  // Manage Channels or Manage Server
-  if (!((permissions & (1 << 4)) === (1 << 4) || (permissions & (1 << 5)) === (1 << 5))) {
-    respond('You do not have permission to use /watch command.', 'You need Manage Channels or Manage Server permission to use it.', '#ff0000', true);
+  if (!user_permissions.has(Permissions.FLAGS.MANAGE_THREADS)) {
+    respond('You do not have permission to use /watch command.', 'You need Manage Threads permission to use it.', '#ff0000', true);
     return;
   }
 


### PR DESCRIPTION
Check for Manage Threads (`MANAGE_THREADS`) permission using discord.js's `has` method.

Close #20