### PR TITLE
Bold part of responses of /watch

### DIFF
--- a/locale.json
+++ b/locale.json
@@ -39,11 +39,11 @@
         "sv-SE": "Bot skapad av Family friendly#6191"
     },
     "watch_on": {
-        "en-GB": "bot will make sure <#{id}> is un-archived",
+        "en-GB": "bot **will make sure** <#{id}> is un-archived",
         "sv-SE": "botten kommer se till att <#{id}> är o-arkiverad"
     },
     "watch_off": {
-        "en-GB": "bot will no longer keep <#{id}> un-archived",
+        "en-GB": "bot **will no longer keep** <#{id}> un-archived",
         "sv-SE": "botten kommer ej längre hålla <#{id}> o-arkiverad"
     },
     "watch_issue_add": {


### PR DESCRIPTION
This is quick solution for now to make what `/watch` command did (either watch or unwatch) by bolding the part.
In the future we can think about other ways to make it more obvious and make more clear visual difference, etc.