### PR TITLE
Update for threadUpdate event

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,8 +117,8 @@ client.on('threadUpdate', (oldThread, newThread) => {
     return;
   }
 
-  // This should be newThread.unarchivable && !newThread.locked once discordjs/discord.js#7406 is merged.
-  if (newThread.archived && newThread.sendable && !newThread.locked) {
+  // This should be !newThread.unarchivable && newThread.locked once discordjs/discord.js#7406 is merged.
+  if (!(newThread.archived || newThread.sendable) || newThread.locked) {
     logger.warn(`[auto] Skipped ${newThread.id} in ${newThread.guildId}. (archived: ${newThread.archived}, bot has permissions: ${checkIfBotCanManageThread(newThread.guildId, newThread.parentId)})`);
     return;
   }


### PR DESCRIPTION
## Changes
* Ignore locked threads
* Check for being `ThreadChannel.sendable`. Manage Threads (`MANAGE_THREADS`) is not required to unarchive unlocked threads.
  * Note that this includes small workaround because of discordjs/discord.js#7406.