### PR TITLE
Minor update for /threads

### DIFF
--- a/locale.json
+++ b/locale.json
@@ -109,6 +109,10 @@
     "ko": "잠김",
     "sv-SE": "låst"
   },
+  "threads-status-unknown-thread": {
+    "en-US": "unknown thread",
+    "ko": "알 수 없는 스레드"
+  },
   "threads-title": {
     "en-US": "Watched threads",
     "ko": "주시된 스레드",


### PR DESCRIPTION
* Show IDs for threads that cannot be fetched and mark them as "unknown channel"
* Internal changes
  * Only try to fetch threads when `i` is 1 to future-proof
  * Split list item handling from status check iteration
  * Remove `channel_lists` and `thread_lists` constants outside of the first-level iteration and declare `items` and `lists` constants directly into it since they are never used outside of it
* Add `threads-status-unknown-thread` locale string
  * Note: Currently `watch-watch-unarchive-reason` is also missing Swedish translation, so please add it for both `threads-status-unknown-thread` and `watch-watch-unarchive-reason` after merging this pull request.