### PR TITLE
Major rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ check [commands](https://familyfriendly.xyz/thread)
 The bot keeps the thread id and the connected server id in its database. This is required for the bot to work and the data is removed once watch of a channel is toggled off
 
 ## My instance
-you can add my instance of the bot [here](https://discord.com/oauth2/authorize?client_id=870715447136366662&scope=bot%20applications.commands&permissions=122406571008)
+you can add my instance of the bot [here](https://discord.com/oauth2/authorize?client_id=870715447136366662&permissions=274877973504&scope=applications.commands%20bot)
 
 ## Support
 join my discord server for any support or suggestions. [click here](https://discord.gg/793fagUfmr)

--- a/_config.js
+++ b/_config.js
@@ -20,5 +20,5 @@ module.exports = {
     },
     owners: [ "286224826170081290" ],
     applicationId: "592814450084675594",
-    invite: "https://discord.com/oauth2/authorize?client_id=870715447136366662&scope=bot%20applications.commands&permissions=122406571008",
+    invite: "https://discord.com/oauth2/authorize?client_id=870715447136366662&permissions=274877973504&scope=applications.commands%20bot",
 }

--- a/commands/auto.js
+++ b/commands/auto.js
@@ -1,7 +1,7 @@
-const channels = require('../index').channels,
-  getText = require('../utils/getText'),
-  { addThread, removeThread } = require('../utils/threadActions'),
-  { CommandInteraction, Permissions } = require('discord.js');
+const channels = require('../index').channels;
+const getText = require('../utils/getText');
+const { addThread, removeThread } = require('../utils/threadActions'),
+const { CommandInteraction, Permissions } = require('discord.js');
 
 /**
  * @param {*} client
@@ -17,8 +17,7 @@ const run = (client, interaction, handleBaseEmbed) => {
     handleBaseEmbed(title, description, false, '#dd3333', true, true);
     return;
   }
-
-  if (!interaction.member.permissionsIn(channel).has([
+  else if (!interaction.member.permissionsIn(channel).has([
     Permissions.FLAGS.MANAGE_THREADS,
     Permissions.FLAGS.VIEW_CHANNEL
   ])) {
@@ -27,8 +26,7 @@ const run = (client, interaction, handleBaseEmbed) => {
     handleBaseEmbed(title, description, false, '#dd3333', true, true);
     return;
   }
-
-  if (channels.has(channel.id)) {
+  else if (channels.has(channel.id)) {
     try {
       removeThread(channel.id, 'channels');
 
@@ -48,8 +46,7 @@ const run = (client, interaction, handleBaseEmbed) => {
 
     return;
   }
-
-  if (!(channel.viewable && interaction.guild.me.permissionsIn(channel).has(Permissions.FLAGS.SEND_MESSAGES_IN_THREADS))) {
+  else if (!(channel.viewable && interaction.guild.me.permissionsIn(channel).has(Permissions.FLAGS.SEND_MESSAGES_IN_THREADS))) {
     const description = getText('auto-register-bot-access-denied-description', interaction.locale);
     const title = getText('auto-register-bot-access-denied-title', interaction.locale);
     handleBaseEmbed(title, description, false, '#dd3333', true, true);

--- a/commands/batch.js
+++ b/commands/batch.js
@@ -1,165 +1,245 @@
-const { threads } = require('../index'),
-  { addThread, removeThread } = require('../utils/threadActions.js'),
-  { CommandInteraction, TextChannel, Permissions } = require('discord.js');
+const getText = require('../utils/getText');
+const { addThread, removeThread } = require('../utils/threadActions');
+const { CommandInteraction, Permissions } = require('discord.js');
+const { threads } = require('../index');
 
 /**
- * 
- * @param {TextChannel} channel 
- * @param {string} action 
- * @param {RegExp} pattern 
+ * @param {string} action
+ * @param {*} parent
+ * @param {regexp} pattern_regex
+ * @param {boolean} pattern_inverted
+ * @param {*} bot_member
+ * @param {*} user_member
+ * @param {string} server_locale
  */
-const batchInChannel = async (channel, action, pattern = null ) => {
-  // make sure all threads are in cache
-  if(channel.permissionsFor(channel.members.get(channel.client.user.id))?.has(Permissions.FLAGS.READ_MESSAGE_HISTORY))  {
-    await channel.threads.fetchActive();
-    await channel.threads.fetchArchived();
-  }
+const runBatchActions = async (action, parent, pattern_regex, pattern_inverted, bot_member, user_member, server_locale) => {
+  const channels = parent.isText() ? [parent] : parent.children.values();
 
-  return new Promise((resolve, reject) => {
-    let rv = {
-      succeeded: 0,
-      failed: 0
-    };
+  const results = {
+    failed: {
+      bot_cannot_fetch: 0,
+      bot_cannot_unarchive: 0,
+      error: 0,
+      locked: 0,
+      user_access_denied: 0
+    },
+    succeed: 0
+  };
 
-    const [ reg, blacklist ] = pattern;
+  for (const channel of channels) {
+    if (!(channel.viewable && bot_member.permissionsIn(channel).has(Permissions.FLAGS.READ_MESSAGE_HISTORY))) {
+      results.failed.bot_cannot_fetch++;
+      continue;
+    }
 
-    channel.threads.cache.each(t => {
-      try {
-        if(!t.manageable) {
-          rv.failed++
-        } else {
-          const name = t.name;
-          const id = t.id;
+    for (const thread of channel.threads.cache.values()) {
+      if (pattern_regex !== null) {
+        const pattern_match = pattern_regex.test(thread.name);
 
-          if (t.parentId !== channel.id || (threads.has(id) && action === 'watch') || reg ? (blacklist ? name.match(reg) : !name.match(reg)) : false) {
-            return;
-          }
-
-          if (action === 'watch') {
-            addThread(id, channel.guildId, (Date.now() / 1000) + (t.autoArchiveDuration * 60));
-
-            if (t.archived) {
-              t.setArchived(false, 'automatic');
-            }
-          }
-          else {
-            removeThread(id);
-          }
-
-          rv.succeeded++;
+        if (pattern_inverted ? pattern_match : !pattern_match) {
+          continue;
         }
       }
-      catch(err) {
-        rv.failed++;
+
+      if (!user_member.permissionsIn(thread).has([
+        Permissions.FLAGS.MANAGE_THREADS,
+        Permissions.FLAGS.READ_MESSAGE_HISTORY,
+        Permissions.FLAGS.VIEW_CHANNEL
+      ])) {
+        results.failed.user_access_denied++;
+        continue;
       }
+      else if (threads.has(thread.id)) {
+        if (action === 'unwatch') {
+          try {
+            removeThread(thread.id);
+            results.succeed++;
+          }
+          catch {
+            results.failed.error++;
+          }
+        }
+
+        continue;
+      }
+      else if (thread.locked) {
+        results.failed.locked++;
+        continue;
+      }
+      // No need to check for thread.viewable
+      else if (!thread.sendable) {
+        results.failed.bot_cannot_unarchive++;
+        continue;
+      }
+
+      try {
+        addThread(thread.id, thread.guildId, (Date.now() / 1000) + (thread.autoArchiveDuration * 60));
+
+        if (thread.archived) {
+          const unarchive_reason = getText('unarchive-reason-watch-archived', server_locale);
+          thread.setArchived(false, unarchive_reason);
+        }
+
+        results.succeed++;
+      }
+      catch {
+        results.failed.error++;
+      }
+    }
+  }
+
+  return results;
+};
+
+/**
+ * @param {*} client
+ * @param {CommandInteraction} interaction
+ * @param {function} handleBaseEmbed
+ */
+const run = async (client, interaction, handleBaseEmbed) => {
+  const action = interaction.options.getString('action');
+  const parent = interaction.options.getChannel('parent') ?? interaction.channel;
+  const pattern = interaction.options.getString('pattern');
+
+  if (parent.isThread()) {
+    const description = getText('batch-channel-type-not-allowed', interaction.locale);
+    const title = getText('channel-type-not-allowed', interaction.locale);
+    handleBaseEmbed(title, description, false, '#dd3333', true, true);
+    return;
+  }
+
+  let pattern_inverted;
+  let pattern_regex = null;
+
+  if (!(pattern === null || pattern === '')) {
+    const invalid_pattern_description = getText('batch-invalid-pattern-description', interaction.locale);
+    const invalid_pattern_title = getText('batch-invalid-pattern-title', interaction.locale);
+
+    if (pattern === '!') {
+      handleBaseEmbed(invalid_pattern_title, invalid_pattern_description, false, '#dd3333', true, true);
+      return;
+    }
+
+    pattern_inverted = pattern.startsWith('!');
+    const parsed_pattern = pattern_inverted ? pattern.replace('!', '') : pattern;
+
+    if (!parsed_pattern.match(/^[\w!*]{0,100}$/gm)) {
+      handleBaseEmbed(invalid_pattern_title, invalid_pattern_description, false, '#dd3333', true, true);
+      return;
+    }
+
+    pattern_regex = new RegExp(parsed_pattern.replace('*', '\\w*'));
+  }
+
+  await interaction.deferReply();
+  const results = await runBatchActions(action, parent, pattern_regex, pattern_inverted, interaction.guild.me, interaction.member, interaction.guildLocale);
+  const failed_channel_amount = 0;
+  const failed_thread_amount = 0;
+  const fields = [];
+  const title_locale_string = (action === 'watch') ? 'batch-watch-done' : 'batch-unwatch-done';
+  const title = getText(title_locale_string, interaction.locale);
+
+  if (results.failed.bot_cannot_fetch > 0) {
+    const field_name = getText('batch-field-bot-cannot-fetch-name', interaction.locale, {
+      'channel-amount': results.failed.bot_cannot_fetch
     });
 
-    resolve(rv);
+    const field_value = getText('batch-field-bot-cannot-fetch-value', interaction.locale);
+    fields.push([field_name, field_value]);
+    failed_channel_amount += results.failed.bot_cannot_fetch;
+  }
+
+  if (results.failed.bot_cannot_unarchive > 0) {
+    const field_name = getText('batch-field-bot-cannot-unarchive-name', interaction.locale, {
+      'thread-amount': results.failed.bot_cannot_unarchive
+    });
+
+    const field_value = getText('batch-field-bot-cannot-unarchive-value', interaction.locale);
+    fields.push([field_name, field_value]);
+    failed_thread_amount += results.failed.bot_cannot_unarchive;
+  }
+
+  if (results.failed.error > 0) {
+    const field_name_locale_string = (action === 'watch') ? 'batch-watch-field-error' : 'batch-unwatch-field-error';
+
+    const field_name = getText(field_name_locale_string, interaction.locale, {
+      'thread-amount': results.failed.error
+    });
+
+    const field_value = getText('unknown-error-occurred', interaction.locale);
+    fields.push([field_name, field_value]);
+    failed_thread_amount += results.failed.error;
+  }
+
+  if (results.failed.locked > 0) {
+    const field_name = getText('batch-field-locked-name', interaction.locale, {
+      'thread-amount': results.failed.locked
+    });
+
+    const field_value = getText('batch-field-locked-value', interaction.locale);
+    fields.push([field_name, field_value]);
+    failed_thread_amount += results.failed.locked;
+  }
+
+  if (results.failed.user_access_denied > 0) {
+    const field_name = getText('batch-field-user-access-denied-name', interaction.locale, {
+      'thread-amount': results.failed.user_access_denied
+    });
+
+    const field_value = getText('batch-field-user-access-denied-value', interaction.locale);
+    fields.push([field_name, field_value]);
+    failed_thread_amount += results.failed.user_access_denied;
+  }
+
+  const description = getText('batch-results', interaction.locale, {
+    'failed-channel-amount': failed_channel_amount,
+    'failed-thread-amount': failed_thread_amount,
+    'succeed-thread-amount': results.succeed
+  });
+
+  const embed = handleBaseEmbed(title, description, true, '#3366cc', false, null);
+
+  for (const field of fields) {
+    embed.addField(...field);
+  }
+
+  interaction.editReply({
+    embeds: [embed]
   });
 };
 
-/**
- * 
- * @param {*} client 
- * @param {CommandInteraction} interaction 
- * @param {*} respond 
- * @returns 
- */
-const run = async (client, interaction, respond, l) => {
-  const action = interaction.options.getString("action")
-  const parent = interaction.options.getChannel("parent")
-  let pattern = interaction.options.getString("pattern")
-  let blacklist = false;
-
-  if (pattern?.startsWith('!')) {
-    blacklist = true;
-    pattern = pattern.substring(1);
-  }
-
-  if (pattern) {
-    if (pattern.match(/^[a-zA-Z0-9_\*!]{0,100}$/gm)) {
-      pattern = RegExp(pattern.replace('*', '\\w*'));
-    }
-    else {
-      respond('❌ Issue', l("batch_forbidden_characters", { pattern }), '#ff0000', true);
-      return;
-    }
-  }
-
-  let actions = {
-    succeeded: 0,
-    failed: 0
-  };
-
-
-  // I apologise to the brave soul reading thread watchers code. This is horrible but it works
-  const doBatchThing = () => {
-    return new Promise(async (resolve, reject) => {
-      if (parent.type === 'GUILD_CATEGORY') {
-
-        for(const _channel of Array.from(parent.children)) {
-          const channel = _channel[1]
-          if(channel.viewable) {
-            const a = await batchInChannel(channel, action, [ pattern, blacklist ])
-            actions.succeeded += a.succeeded
-            actions.failed += a.failed;
-          }
-        }
-        resolve()
-      }
-      else {
-        let a = await batchInChannel(parent, action, [ pattern, blacklist ])
-        actions = a
-        resolve()
-      }
-
-      
-    })
-  }
-
-  interaction.deferReply()
-  .then(_d => {
-    doBatchThing()
-    .then(_res => {
-      //`🟢 ${actions.succeeded} succeeded. 🔴 ${actions.failed} failed`
-      respond(l(`batch_${action.replace("_","")}`), l("batch_result", { succeeded: actions.succeeded, failed: actions.failed }), '#008000');
-    })
-  })
-};
-
 const data = {
-  name:"batch",
-  description: "batch add/remove threads to watch",
+  description: 'Batch watch or unwatch multiple threads.',
+  name: 'batch',
   options: [
-      {
-          name: "action",
-          description: "what action to apply to the threads",
-          required: true,
-          type: 3,
-          choices: [
-              {
-                  name: "watch",
-                  value: "watch"
-              },
-              {
-                  name: "un-watch",
-                  value: "unwatch"
-              }
-          ]
-      },
-      {
-          name: "parent",
-          description: "The parent channel or category whose threads you want to apply an action to",
-          type: 7,
-          required: true,
-          channel_types: [0, 4, 5]
-      },
-      {
-          name: "pattern",
-          description: "specify which channels by name to apply an action to. Check website for more info",
-          type: 3
-      }
+    {
+      choices: [
+        {
+          name: 'watch',
+          value: 'watch'
+        },
+        {
+          name: 'unwatch',
+          value: 'unwatch'
+        }
+      ],
+      description: 'Action to run',
+      name: 'action',
+      required: true,
+      type: 3
+    },
+    {
+      channel_types: [0, 4, 5],
+      description: 'Category or channel to run batch actions',
+      name: 'parent',
+      type: 7
+    },
+    {
+      description: 'Run batch actions only on threads whose name match this pattern',
+      name: 'pattern',
+      type: 3
+    }
   ]
-}
+};
 
 module.exports = { run, data };

--- a/commands/info.js
+++ b/commands/info.js
@@ -51,7 +51,7 @@ const run = (client, interaction, respond) => {
     invite.setEmoji("🤖")
     invite.setStyle("LINK")
     invite.setLabel("Invite Thread Watcher")
-    invite.setURL("https://discord.com/oauth2/authorize?client_id=870715447136366662&scope=bot%20applications.commands&permissions=122406571008")
+    invite.setURL("https://discord.com/oauth2/authorize?client_id=870715447136366662&permissions=274877973504&scope=applications.commands%20bot")
     
     //support server
     const support = new MessageButton()

--- a/commands/threads.js
+++ b/commands/threads.js
@@ -27,13 +27,13 @@ const run = async (client, interaction, handleBaseEmbed) => {
       let channel_like = null;
 
       if (i === 1) {
-        for (const [channel_id, channel] of interaction.guild.channels.cache) {
+        for (const channel of interaction.guild.channels.cache.values()) {
           if (!('threads' in channel)) {
             continue;
           }
 
-          for (const [thread_id, thread] of channel.threads.cache) {
-            if (thread_id === db_channel_like.id) {
+          for (const thread of channel.threads.cache.values()) {
+            if (thread.id === db_channel_like.id) {
               channel_like = thread;
               break;
             }

--- a/commands/watch.js
+++ b/commands/watch.js
@@ -1,7 +1,7 @@
-const threads = require('../index').threads,
-  getText = require('../utils/getText'),
-  { addThread, removeThread } = require('../utils/threadActions'),
-  { CommandInteraction, Permissions } = require('discord.js');
+const getText = require('../utils/getText');
+const threads = require('../index').threads;
+const { addThread, removeThread } = require('../utils/threadActions');
+const { CommandInteraction, Permissions } = require('discord.js');
 
 /**
  * @param {*} client
@@ -17,16 +17,14 @@ const run = (client, interaction, handleBaseEmbed) => {
     handleBaseEmbed(title, description, false, '#dd3333', true, true);
     return;
   }
-
   // Users cannot specify a thread they cannot view, so no need to check for VIEW_CHANNEL.
-  if (!interaction.member.permissionsIn(thread).has(Permissions.FLAGS.MANAGE_THREADS)) {
+  else if (!interaction.member.permissionsIn(thread).has(Permissions.FLAGS.MANAGE_THREADS)) {
     const description = getText('watch-user-access-denied', interaction.locale);
     const title = getText('user-access-denied', interaction.locale);
     handleBaseEmbed(title, description, false, '#dd3333', true, true);
     return;
   }
-
-  if (threads.has(thread.id)) {
+  else if (threads.has(thread.id)) {
     try {
       removeThread(thread.id);
 
@@ -46,15 +44,13 @@ const run = (client, interaction, handleBaseEmbed) => {
 
     return;
   }
-
-  if (thread.locked) {
+  else if (thread.locked) {
     const description = getText('watch-watch-locked-description', interaction.locale);
     const title = getText('watch-watch-locked-title', interaction.locale);
     handleBaseEmbed(title, description, false, '#dd3333', true, true);
     return;
   }
-
-  if (!(thread.viewable && thread.sendable)) {
+  else if (!(thread.viewable && thread.sendable)) {
     const description = getText('watch-watch-bot-access-denied-description', interaction.locale);
     const title = getText('watch-watch-bot-access-denied-title', interaction.locale);
     handleBaseEmbed(title, description, false, '#dd3333', true, true);
@@ -63,8 +59,11 @@ const run = (client, interaction, handleBaseEmbed) => {
 
   try {
     addThread(thread.id, interaction.guildId, (Date.now() / 1000) + (thread.autoArchiveDuration * 60));
-    const unarchive_reason = getText('watch-watch-unarchive-reason', interaction.guildLocale);
-    thread.setArchived(false, unarchive_reason);
+
+    if (thread.archived) {
+      const unarchive_reason = getText('unarchive-reason-watch-archived', server_locale);
+      thread.setArchived(false, unarchive_reason);
+    }
 
     const description = getText('watch-watch-ok-description', interaction.locale, {
       thread: thread.toString()

--- a/front/index.html
+++ b/front/index.html
@@ -2,10 +2,9 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="./index.css">
-    <title>Thread Watcher</title>
+    <title>Thread-Watcher</title>
 </head>
 <body>
     <div class="navbar">
@@ -18,7 +17,7 @@
             <ul>
                 <li class="first"></li>
                 <a href="https://discord.gg/793fagUfmr"><li>Support</li></a>
-                <a href="https://discord.com/oauth2/authorize?client_id=870715447136366662&scope=bot%20applications.commands&permissions=122406571008"><li>Invite</li></a>
+                <a href="https://discord.com/oauth2/authorize?client_id=870715447136366662&permissions=274877973504&scope=applications.commands%20bot"><li>Invite</li></a>
                 <a href="https://top.gg/bot/870715447136366662"><li>Vote</li></a>
                 <li class="last"></li>
             </ul>

--- a/index.js
+++ b/index.js
@@ -111,11 +111,6 @@ client.on('interactionCreate', (interaction) => {
     return embed;
   };
 
-  // Deprecated: Use getText() instead.
-  const l = (label, obj) => {
-    return getText(label, interaction.locale, obj);
-  };
-
   // Deprecated: Use handleBaseEmbed() instead.
   const respond = (title, description, color = '#008000', ephemeral = false) => {
     handleBaseEmbed(title, description, true, color, true, ephemeral);
@@ -135,27 +130,12 @@ client.on('interactionCreate', (interaction) => {
     return;
   }
 
-  // Backward compatibility for /batch
-  if (interaction.commandName === 'batch') {
-    const channelId = interaction.options.getChannel('parent');
-
-    if (!checkIfBotCanManageThread(null, channelId.id)) {
-      respond(getText('interaction-error', interaction.locale), getText('needs_manage_threads', interaction.locale), '#dd3333', true);
-      return;
-    }
-
-    if (!interaction.memberPermissions.has(Discord.Permissions.FLAGS.MANAGE_THREADS)) {
-      respond(getText('user-access-denied', interaction.locale), getText('user_needs_manage_threads', interaction.locale), '#dd3333', true);
-      return;
-    }
-  }
-
   const cmd = client.commands.get(interaction.commandName);
 
   try {
-    // Backward compatibility for /batch and /diagnose
-    if (interaction.commandName === 'batch' || interaction.commandName === 'diagnose') {
-      cmd.run(client, interaction, respond, l);
+    // Backward compatibility for /diagnose
+    if (interaction.commandName === 'diagnose') {
+      cmd.run(client, interaction, respond);
     }
     else {
       cmd.run(client, interaction, handleBaseEmbed);
@@ -219,7 +199,7 @@ client.on('threadUpdate', (oldThread, newThread) => {
     return;
   }
 
-  const unarchive_reason = getText('unarchive-keep-active-reason', newThread.guild.preferredLocale);
+  const unarchive_reason = getText('unarchive-reason-keep-active', newThread.guild.preferredLocale);
   newThread.setArchived(false, unarchive_reason);
   logger.done(`[auto] (${getDate()}) Unarchived ${newThread.id} thread in ${newThread.guildId} server.`);
   db.updateArchiveTimes(newThread.id, (Date.now() / 1000) + (newThread.autoArchiveDuration * 60));

--- a/locale.json
+++ b/locale.json
@@ -22,10 +22,15 @@
     "ko": "상호 작용을 처리할 수 없습니다.",
     "sv-SE": "Kunde inte hantera interaktionen."
   },
-  "unarchive-keep-active-reason": {
+  "unarchive-reason-keep-active": {
     "en-US": "Keep the thread active",
     "ko": "스레드를 활성 상태로 유지",
     "sv-SE": "Håll tråden aktiv."
+  },
+  "unarchive-reason-watch-archived": {
+    "en-US": "Watch archived thread",
+    "ko": "보관된 스레드 주시",
+    "sv-SE": "Registrera arkiverad tråd"
   },
   "unknown-error-occurred": {
     "en-US": "Unknown error occurred.",
@@ -89,6 +94,71 @@
     "sv-SE": "du behöver Hantera Trådar rättigheten i kanalen."
   },
 
+  "batch-channel-type-not-allowed": {
+    "en-US": "You must specify announcement channel, category or text channel or use this command in it.",
+    "ko": "공지 채널, 카테고리나 텍스트 채널을 지정하거나 그 채널에서 명령어를 사용해야 합니다."
+  },
+  "batch-field-bot-cannot-fetch-name": {
+    "en-US": "Bot cannot fetch the list of threads. ({channel-amount} channels)",
+    "ko": "봇이 스레드 목록을 가져올 수 없습니다. (채널 {channel-amount}개)"
+  },
+  "batch-field-bot-cannot-fetch-value": {
+    "en-US": "Bot needs Read Message History permission in those channels.",
+    "ko": "봇이 해당 채널에서 Read Message History 권한이 필요합니다."
+  },
+  "batch-field-bot-cannot-unarchive-name": {
+    "en-US": "Bot cannot unarchive threads. ({thread-amount} threads)",
+    "ko": "봇이 스레드를 보관 해제할 수 없습니다. (스레드 {thread-amount}개)"
+  },
+  "batch-field-bot-cannot-unarchive-value": {
+    "en-US": "Bot needs Send Messages in Threads permission in channels which those threads are in.\nIf you want to watch private threads, they also need Manage Threads permission or to be invited to them.",
+    "ko": "봇이 해당 스레드가 있는 채널에서 Send Messages in Threads 권한이 필요합니다.\n비공개 스레드도 주시하고 싶다면 Manage Threads 권한이나 스레드 초대도 필요합니다."
+  },
+  "batch-field-locked-name": {
+    "en-US": "Threads are locked. ({thread-amount} threads)",
+    "ko": "스레드가 잠겼습니다. (스레드 {thread-amount}개)"
+  },
+  "batch-field-locked-value": {
+    "en-US": "Bot does not keep locked threads active.",
+    "ko": "봇은 잠긴 스레드를 활성 상태로 유지하지 않습니다."
+  },
+  "batch-field-user-access-denied-name": {
+    "en-US": "You do not have permission to do this. ({thread-amount} threads)",
+    "ko": "해당 명령을 수행할 권한이 없습니다. (스레드 {thread-amount}개)"
+  },
+  "batch-field-user-access-denied-value": {
+    "en-US": "You need Manage Threads and Read Message History permissions in channels which those threads are in.",
+    "ko": "해당 스레드가 있는 채널에서 Manage Threads와 Read Message History 권한이 필요합니다."
+  },
+  "batch-invalid-pattern-description": {
+    "en-US": "Only alphanumeric characters, `_`, `!` and `*` are allowed.\nYou cannot use only single `!` without pattern.",
+    "ko": "알파벳, 숫자, `_`, `!`와 `*`만 허용됩니다.\n패턴 없이 `!` 하나만 사용할 수 없습니다."
+  },
+  "batch-invalid-pattern-title": {
+    "en-US": "Pattern is invalid.",
+    "ko": "패턴이 잘못되었습니다."
+  },
+  "batch-results": {
+    "en": "Succeed: {succeed-thread-amount} threads\nFailed: {failed-channel-amount} channels, {failed-thread-amount} threads",
+    "ko": "성공: 스레드 {succeed-thread-amount}개\n실패: 채널 {failed-channel-amount}개, 스레드 {failed-thread-amount}개"
+  },
+  "batch-unwatch-done": {
+    "en-US": "Batch unwatched threads.",
+    "ko": "스레드를 일괄 주시 해제했습니다."
+  },
+  "batch-unwatch-field-error": {
+    "en-US": "Cannot unwatch threads. ({thread-amount} threads)",
+    "ko": "스레드를 주시 해제할 수 없습니다. (스레드 {thread-amount}개)"
+  },
+  "batch-watch-done": {
+    "en-US": "Batch watched threads.",
+    "ko": "스레드를 일괄 주시했습니다."
+  },
+  "batch-watch-field-error": {
+    "en-US": "Cannot watch threads. ({thread-amount} threads)",
+    "ko": "스레드를 주시할 수 없습니다. (스레드 {thread-amount}개)"
+  },
+
   "threads-description": {
     "en-US": "{thread-amount} threads are watched. Threads you cannot see are not shown.",
     "ko": "스레드 {thread-amount}개가 주시되었습니다. 볼 수 없는 스레드는 표시되지 않습니다.",
@@ -146,9 +216,9 @@
     "sv-SE": "Du behöver hantera trådar rättigheten i kanelen som tråden är i."
   },
   "watch-watch-bot-access-denied-description": {
-    "en-US": "Bot needs Send Messages in Threads permission in the channel which specified thread is in.\nIf it is private thread, they also need Manage Threads permission or to be invited to it.",
+    "en-US": "Bot needs Send Messages in Threads permission in the channel which that thread is in.\nIf it is private thread, they also need Manage Threads permission or to be invited to it.",
     "ko": "봇이 해당 스레드가 있는 채널에서 Send Messages in Threads 권한이 필요합니다.\n비공개 스레드인 경우 Manage Threads 권한이나 스레드 초대도 필요합니다.",
-    "sv-SE": "Botten behöver kunna skicka medelanden i tråden. Om det är en privat tråd så behöver botten rättigheten att hantera trådar eller en inbjudan till tråden."
+    "sv-SE": "[Translation outdated] Botten behöver kunna skicka medelanden i tråden. Om det är en privat tråd så behöver botten rättigheten att hantera trådar eller en inbjudan till tråden."
   },
   "watch-watch-bot-access-denied-title": {
     "en-US": "Bot cannot unarchive the thread.",
@@ -179,39 +249,5 @@
     "en-US": "Watched the thread.",
     "ko": "스레드를 주시했습니다.",
     "sv-SE": "Registrerade tråden."
-  },
-  "watch-watch-unarchive-reason": {
-    "en-US": "Watch archived thread",
-    "ko": "보관된 스레드 주시",
-    "sv-SE": "Registrera arkiverad tråd"
-  },
-
-  "done": {
-    "en-US": "done",
-    "sv-SE": "klart"
-  },
-  "needs_manage_threads": {
-    "en-US": "bot needs `SEND_MESSAGES_IN_THREADS` for this command",
-    "sv-SE": "botten behöver `SEND_MESSAGES_IN_THREADS` för detta kommando"
-  },
-  "user_needs_manage_threads": {
-    "en-US": "you need `MANAGE_THREADS` to use it.",
-    "sv-SE": "du behöver `MANAGE_THREADS` för att använda det."
-  },
-  "batch_forbidden_characters": {
-    "en-US": "your pattern \"{pattern}\" includes forbidden characters",
-    "sv-SE": "ditt text-mönster \"{pattern}\" innehåller förbjudna tecken"
-  },
-  "batch_result": {
-    "en-US": "🟢 {succeeded} succeeded. 🔴 {failed} failed",
-    "sv-SE": "🟢 {succeeded} lyckades. 🔴 {failed} misslyckades"
-  },
-  "batch_watch" : {
-    "en-US": "Threads were watched.",
-    "sv-SE": "Trådarna tillagda."
-  },
-  "batch_unwatch" : {
-    "en-US": "Threads were unwatched.",
-    "sv-SE": "Trådenarna borttagna från listan."
   }
 }


### PR DESCRIPTION
* Rewrite `/batch` handling
  * Make `parent` option optional
  * Check permissions per-channel and per-thread
  * Prevent watching locked threads
  * Require both Manage Threads and Read Message History permissions
  * Show reasons for failed channels and threads
* Change permissions for bot add link to ask Read Message History, Send Messages in Threads and View Channels permissions
* Some internal changes and code style fixes
  * Use `TextBasedChannel.values()` for `/threads` handling to iterate over channels and threads without Snowflake IDs