### PR TITLE
Minor fixes and changes

### DIFF
--- a/commands/batch.js
+++ b/commands/batch.js
@@ -6,7 +6,7 @@ const { threads } = require('../index');
 /**
  * @param {string} action
  * @param {*} parent
- * @param {regexp} pattern_regex
+ * @param {RegExp} pattern_regex
  * @param {boolean} pattern_inverted
  * @param {*} bot_member
  * @param {*} user_member
@@ -123,7 +123,7 @@ const run = async (client, interaction, handleBaseEmbed) => {
     pattern_inverted = pattern.startsWith('!');
     const parsed_pattern = pattern_inverted ? pattern.replace('!', '') : pattern;
 
-    if (!parsed_pattern.match(/^[\w!\*]{0,100}$/gm)) {
+    if (!/^[\w!*]{0,100}$/gm.test(parsed_pattern)) {
       handleBaseEmbed(invalid_pattern_title, invalid_pattern_description, false, '#dd3333', true, true);
       return;
     }

--- a/commands/watch.js
+++ b/commands/watch.js
@@ -6,7 +6,7 @@ const { CommandInteraction, Permissions } = require('discord.js');
 /**
  * @param {*} client
  * @param {CommandInteraction} interaction
- * @param {function} handleBaseEmbed
+ * @param {Function} handleBaseEmbed
  */
 const run = (client, interaction, handleBaseEmbed) => {
   const thread = interaction.options.getChannel('thread') ?? interaction.channel;
@@ -61,7 +61,7 @@ const run = (client, interaction, handleBaseEmbed) => {
     addThread(thread.id, interaction.guildId, (Date.now() / 1000) + (thread.autoArchiveDuration * 60));
 
     if (thread.archived) {
-      const unarchive_reason = getText('unarchive-reason-watch-archived', server_locale);
+      const unarchive_reason = getText('unarchive-reason-watch-archived', interaction.guildLocale);
       thread.setArchived(false, unarchive_reason);
     }
 

--- a/index.js
+++ b/index.js
@@ -23,17 +23,6 @@ const asMap = ( data ) => {
     return m
 }
 
-// keeping sid in this function because i'm too lazy to change all refferences to checkIfBotCanManageThread
-const checkIfBotCanManageThread = (server_id, channel_id) => {
-    const channel = client.channels.cache.get(channel_id);
-
-    if (!channel) {
-      return false;
-    }
-
-    return channel.isThread() ? channel.sendable : channel.permissionsFor(channel.guild.me).has(Discord.Permissions.FLAGS.SEND_MESSAGES_IN_THREADS);
-}
-
 const init = async () => {
 
     // wait for the required tables to be created
@@ -82,7 +71,7 @@ const loadCommands = (clearcache) => {
     client.commands = new Map(fs.readdirSync("./commands").filter(f => f.endsWith(".js")).map(f => [f.split(".js")[0],require(`./commands/${f}`)]))
 }
 
-module.exports = { db, client, checkIfBotCanManageThread, loadCommands, threads, channels };
+module.exports = { db, client, loadCommands, threads, channels };
 
 loadCommands()
 
@@ -128,11 +117,6 @@ client.on('interactionCreate', (interaction) => {
     return embed;
   };
 
-  // Deprecated: Use handleBaseEmbed() instead.
-  const respond = (title, description, color = '#008000', ephemeral = false) => {
-    handleBaseEmbed(title, description, true, color, true, ephemeral);
-  };
-
   if (!interaction.isCommand()) {
     return;
   }
@@ -150,13 +134,7 @@ client.on('interactionCreate', (interaction) => {
   const cmd = client.commands.get(interaction.commandName);
 
   try {
-    // Backward compatibility for /diagnose
-    if (interaction.commandName === 'diagnose') {
-      cmd.run(client, interaction, respond);
-    }
-    else {
-      cmd.run(client, interaction, handleBaseEmbed);
-    }
+    cmd.run(client, interaction, handleBaseEmbed);
   }
   catch (err) {
     logger.warn(JSON.stringify(err));

--- a/locale.json
+++ b/locale.json
@@ -150,9 +150,9 @@
     "sv-SE": "Mönstret är ogiltigt."
   },
   "batch-results": {
-    "en-US": "**Succeeded:** {succeed-thread-amount} threads\n**Failed:** {failed-channel-amount} channels, {failed-thread-amount} threads",
-    "ko": "성공: 스레드 {succeed-thread-amount}개\n실패: 채널 {failed-channel-amount}개, 스레드 {failed-thread-amount}개",
-    "sv-SE": "**Lyckades:** ${succeed-thread-amount} trådar\n**Misslyckades:** {failed-channel-amount} kanaler, {failed-thread-amount} trådar"
+    "en-US": "**Succeeded**: {succeed-thread-amount} threads\n**Failed**: {failed-channel-amount} channels, {failed-thread-amount} threads",
+    "ko": "**성공**: 스레드 {succeed-thread-amount}개\n**실패**: 채널 {failed-channel-amount}개, 스레드 {failed-thread-amount}개",
+    "sv-SE": "**Lyckades**: ${succeed-thread-amount} trådar\n**Misslyckades**: {failed-channel-amount} kanaler, {failed-thread-amount} trådar"
   },
   "batch-unwatch-done": {
     "en-US": "Batch unwatched threads.",


### PR DESCRIPTION
* Use `RegExp.prototype.test()` instead of `String.prototype.match()` for `/batch`
  * All we need to know is whether the pattern matches the regex, not the matched part, don't we?
* Move `checkIfBotCanManageThread()` into `commands/diagnose.js` for now as a workaround
* Fix an issue which occurs when watching archived thread
* Remove `respond()`
* Minor tweaks for bolding for `batch-results` locale string and add bolding for Korean translation of it

Close #43