### PR TITLE
Improvements for /threads

### DIFF
--- a/commands/threads.js
+++ b/commands/threads.js
@@ -1,86 +1,121 @@
-const db = require('../index').db;
-const getText = require('../utils/getText');
-const { CommandInteraction, Permissions } = require('discord.js');
+const DB = require('../index').db;
+const getLocaleString = require('../utils/getText');
+const { Permissions } = require('discord.js');
 
 /**
  * @param {*} client
- * @param {CommandInteraction} interaction
- * @param {function} handleBaseEmbed
+ * @param {*} interaction
+ * @param {Function} handleBaseEmbed
  */
 const run = async (client, interaction, handleBaseEmbed) => {
-  const db_threads = await db.getThreadsInGuild(interaction.guildId);
+  const [activeFetchedThreads, channelCollection, watchedThreads] = await Promise.all([
+    interaction.guild.channels.fetchActiveThreads(),
+    interaction.guild.channels.fetch(),
+    DB.getThreadsInGuild(interaction.guildId),
+    interaction.deferReply({
+      ephemeral: true
+    })
+  ]);
 
-  const description = getText('threads-description', interaction.locale, {
-    'thread-amount': db_threads.length
+  let description = getLocaleString('threads-description-amount', interaction.locale, {
+    'thread-amount': watchedThreads.length
   });
 
-  const title = getText('threads-title', interaction.locale);
+  if (!interaction.memberPermissions.has(Permissions.FLAGS.ADMINISTRATOR)) {
+    const visibilityNotice = getLocaleString('threads-description-visibility', interaction.locale);
+    description += `\n${visibilityNotice}`;
+  }
+
+  const title = getLocaleString('threads-title', interaction.locale);
   const embed = handleBaseEmbed(title, description, false, '#3366cc', false, null);
 
   // This includes future-proofing for adding support to show registered channels.
   for (let i = 1; i <= 1; i++) {
-    const db_channel_likes = (i === 1) ? db_threads : null;
+    const DBChannels = (i === 1) ? watchedThreads : null;
     const items = [];
     const lists = [];
 
-    for (const db_channel_like of db_channel_likes) {
-      let channel_like = null;
+    for (const DBChannel of DBChannels) {
+      let channel = null;
 
       if (i === 1) {
-        for (const channel of interaction.guild.channels.cache.values()) {
-          if (!('threads' in channel)) {
-            continue;
-          }
+        if (activeFetchedThreads.threads.has(DBChannel.id)) {
+          channel = activeFetchedThreads.threads.get(DBChannel.id);
+        }
+        else {
+          for (const currentChannel of channelCollection.values()) {
+            // GuildChannel#isText() should not be used because of forum channels and text-in-voce.
+            if (!('threads' in currentChannel && currentChannel.viewable)) {
+              continue;
+            }
 
-          for (const thread of channel.threads.cache.values()) {
-            if (thread.id === db_channel_like.id) {
-              channel_like = thread;
+            const botPermissions = interaction.guild.me.permissionsIn(currentChannel);
+
+            if (!botPermissions.has(Permissions.FLAGS.READ_MESSAGE_HISTORY)) {
+              continue;
+            }
+
+            const promises = [currentChannel.threads.fetchArchived()];
+
+            if (currentChannel.type === 'GUILD_TEXT') {
+              promises.push(currentChannel.threads.fetchArchived({
+                fetchAll: botPermissions.has(Permissions.FLAGS.MANAGE_THREADS),
+                type: 'private'
+              }));
+            }
+
+            const [archivedPublicFetchedThreads, archivedPrivateFetchedThreads] = await Promise.all(promises);
+            channel = archivedPublicFetchedThreads.threads.get(DBChannel.id) ?? archivedPrivateFetchedThreads?.threads.get(DBChannel.id);
+
+            if (channel !== undefined) {
               break;
             }
           }
         }
       }
       else {
-        channel_like = interaction.guild.channel.cache.get(db_channel_like.id);
+        channel = channelCollection.get(DBChannel.id);
       }
 
-      if (channel_like === null) {
-        const status_unknown_thread = getText('threads-status-unknown-thread', interaction.locale);
-        items.push(`\`${db_channel_like.id}\` (${status_unknown_thread})`);
+      // null or undefined
+      if (channel == null) {
+        const statusUnknownThread = getLocaleString('threads-status-unknown-thread', interaction.locale);
+        items.push(`\`${DBChannel.id}\` (${statusUnknownThread})`);
         continue;
       }
 
-      const user_permissions = interaction.member.permissionsIn(channel_like);
+      const humanPermissions = interaction.member.permissionsIn(channel);
 
-      if (!user_permissions.has(Permissions.FLAGS.VIEW_CHANNEL)) {
+      if (!humanPermissions.has(Permissions.FLAGS.VIEW_CHANNEL)) {
         continue;
       }
-      else if (channel_like.type === 'GUILD_PRIVATE_THREAD' && !(channel_like.members.cache.has(interaction.user.id) || user_permissions.has(Permissions.FLAGS.MANAGE_THREADS))) {
+      // Checking thread membership is not possible because ThreadMemberManager#fetch() requires GUILD_MEMBERS privileged intent.
+      else if (channel.type === 'GUILD_PRIVATE_THREAD' && !humanPermissions.has(Permissions.FLAGS.MANAGE_THREADS)) {
         continue;
       }
 
-      let channel_like_status = null;
+      let status = null;
 
-      if (channel_like.isThread() && channel_like.locked) {
-        channel_like_status = getText('threads-status-locked', interaction.locale);
+      if (channel.isThread() && channel.locked) {
+        status = getLocaleString('threads-status-locked', interaction.locale);
       }
-      else if (channel_like.viewable) {
-        const ok = channel_like.isThread() ? channel_like.sendable : interaction.guild.me.permissionsIn(channel_like).has(Permissions.FLAGS.SEND_MESSAGES_IN_THREADS);
+      else if (channel.viewable) {
+        const ok = channel.isThread() ? channel.sendable : interaction.guild.me.permissionsIn(channel).has(Permissions.FLAGS.SEND_MESSAGES_IN_THREADS);
 
         if (!ok) {
-          channel_like_status = getText('threads-status-cannot-unarchive', interaction.locale);
+          status = getLocaleString('threads-status-cannot-unarchive', interaction.locale);
         }
       }
       else {
-        channel_like_status = getText('threads-status-cannot-unarchive', interaction.locale);
+        status = getLocaleString('threads-status-cannot-unarchive', interaction.locale);
       }
 
-      const item = (channel_like_status === null) ? channel_like.toString() : `~~${channel_like.toString()}~~ (${channel_like_status})`;
+      const item = (status === null) ? channel.toString() : `~~${channel}~~ (${status})`;
       items.push(item);
     }
 
     for (const item of items) {
-      if (lists.length <= 0) {
+      if (lists.length === 0) {
         lists.push(item);
         continue;
       }
@@ -96,19 +131,18 @@ const run = async (client, interaction, handleBaseEmbed) => {
       }
     }
 
-    let first_field = true;
+    let firstField = true;
 
     for (const list of lists) {
-      const first_field_name_locale_string = (i === 1) ? 'threads-field-threads' : null;
-      const field_name = first_field ? getText(first_field_name_locale_string, interaction.locale) : '\u200b';
-      first_field = false;
-      embed.addField(field_name, list);
+      const firstFieldNameStringKey = (i === 1) ? 'threads-field-threads' : null;
+      const fieldName = firstField ? getLocaleString(firstFieldNameStringKey, interaction.locale) : '\u200b';
+      firstField = false;
+      embed.addField(fieldName, list);
     }
   }
 
-  interaction.reply({
-    embeds: [embed],
-    ephemeral: true
+  interaction.editReply({
+    embeds: [embed]
   });
 };
 

--- a/locale.json
+++ b/locale.json
@@ -175,20 +175,24 @@
     "sv-SE": "Kan ej bevaka trådar. ({thread-amount} trådar)"
   },
 
-  "threads-description": {
-    "en-US": "{thread-amount} threads are watched. Threads you cannot see are not shown.",
-    "ko": "스레드 {thread-amount}개가 주시되었습니다. 볼 수 없는 스레드는 표시되지 않습니다.",
-    "sv-SE": "{thread-amount} trådar är bevakade. Trådar som du inte kan se visas ej."
+  "threads-description-amount": {
+    "en-US": "{thread-amount} threads are watched.",
+    "ko": "스레드 {thread-amount}개가 주시되었습니다.",
+    "sv-SE": "{thread-amount} trådar är bevakade."
+  },
+  "threads-description-visibility": {
+    "en-US": "Threads you cannot see are not shown.\nPrivate threads in channels you do not have Manage Threads permission are not shown.",
+    "ko": "볼 수 없는 스레드는 표시되지 않습니다.\nManage Threads 권한이 없는 채널 내 비공개 스레드는 표시되지 않습니다."
   },
   "threads-field-threads": {
     "en-US": "Threads",
     "ko": "스레드",
-    "sv-SE": "trådar."
+    "sv-SE": "trådar"
   },
   "threads-status-cannot-unarchive": {
     "en-US": "cannot unarchive",
     "ko": "보관 해제 불가",
-    "sv-SE": "kan ej av-arkivera."
+    "sv-SE": "kan ej av-arkivera"
   },
   "threads-status-locked": {
     "en-US": "locked",
@@ -198,12 +202,12 @@
   "threads-status-unknown-thread": {
     "en-US": "unknown thread",
     "ko": "알 수 없는 스레드",
-    "sv-SE": "okänd tråd."
+    "sv-SE": "okänd tråd"
   },
   "threads-title": {
     "en-US": "Watched threads",
     "ko": "주시된 스레드",
-    "sv-SE": "Bevakade trådar."
+    "sv-SE": "Bevakade trådar"
   },
 
   "watch-channel-type-not-allowed": {


### PR DESCRIPTION
* Fetch all threads to reduce the chance of threads being labeled as "unknown thread"
  * Fetching archived threads requires `READ_MESSAGE_HISTORY` (Read Message History). `/threads` will skip fetching them if the bot does not have that permission.
* Defer the interaction first before further response
* No longer show the notice about visibility if the user has `ADMINISTRATOR` (Administrator) permission
* Remove checks for membership of private threads, always require `MANAGE_THREADS` (Manage Threads) permission to see watched private threads in the list
  * Thread membership checking has never worked as intended due to lack of `GUILD_MEMBERS` privileged intent.
* Use `Promise.all()` for promises wherever possible to run them simultaneously
* Some other miner code style fixes