### PR TITLE
Optimize archived and unknown thread handling for /threads

### DIFF
--- a/events/threadListSync.js
+++ b/events/threadListSync.js
@@ -1,0 +1,21 @@
+const { cachedUnknownThreads } = require('../index');
+
+function run(client) {
+  client.on('threadListSync', (threads) => {
+    for (const thread of threads.values()) {
+      if (!(thread.guildId in cachedUnknownThreads)) {
+        continue;
+      }
+
+      const unknownThreadsInServer = cachedUnknownThreads[thread.guildId];
+
+      if (unknownThreadsInServer.includes(thread.id)) {
+        unknownThreadsInServer.splice(unknownThreadsInServer.indexOf, 1);
+      }
+    }
+  });
+}
+
+module.exports = {
+  run
+};

--- a/events/threadListSync.js
+++ b/events/threadListSync.js
@@ -10,7 +10,7 @@ function run(client) {
       const unknownThreadsInServer = cachedUnknownThreads[thread.guildId];
 
       if (unknownThreadsInServer.includes(thread.id)) {
-        unknownThreadsInServer.splice(unknownThreadsInServer.indexOf, 1);
+        unknownThreadsInServer.splice(unknownThreadsInServer.indexOf(thread.id), 1);
       }
     }
   });


### PR DESCRIPTION
In #58, I tried to reduce the chance of threads being labeled as "unknown thread", however it introduced unacceptable delay due to taking extremely inefficient way to accomplish that.
This pull request will make the bot fetch the thread directly with `GuildChannelManager#fetch()`, and if it fails, add the ID of it to `cachedUnknownThreads` to prevent making requests guaranteed to get 403/404 error in the future, instead of old behavior of iterations over all channels and fetch archived public/private threads for each of them.
New event handler for `threadListSync` is added to remove a thread from `cachedUnknownThreads` when the bot gains access to it.