### PR TITLE
adds: button to quickly unwatch unknown threads

### DIFF
--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -4,6 +4,16 @@ const Discord = require("discord.js")
 
 const run = ( client ) => {
     client.on('interactionCreate', (interaction) => {
+        /**
+         * 
+         * @param {String} title 
+         * @param {String} description 
+         * @param {Boolean} show_user 
+         * @param {String} color 
+         * @param {Boolean} respond 
+         * @param {Boolean} ephemeral 
+         * @returns {Discord.MessageEmbed}
+         */
         const handleBaseEmbed = (title, description, show_user, color, respond, ephemeral) => {
           const embed = new Discord.MessageEmbed();
           embed.setTitle(title);

--- a/locale.json
+++ b/locale.json
@@ -209,7 +209,27 @@
     "ko": "주시된 스레드",
     "sv-SE": "Bevakade trådar"
   },
-
+  "threads-purgeButton": {
+    "en-US": "Unwatch unknown threads"
+  },
+  "threads-purgeButton-confirmPrompt": {
+    "en-US": "Are you sure?"
+  },
+  "threads-purgeButton-confirm-description": {
+    "en-US": "this will unwatch {number} threads."
+  },
+  "threads-purgeButton-confirm": {
+    "en-US": "confirm"
+  },
+  "threads-purgeButton-cancel": {
+    "en-US": "cancel"
+  },
+  "threads-purgeButton-done": {
+    "en-US": "Success!"
+  },
+  "threads-purgeButton-done-description": {
+    "en-US": "Unknown threads were unwatched."
+  },
   "watch-channel-type-not-allowed": {
     "en-US": "You must specify a thread or use this command in it.",
     "ko": "스레드를 지정하거나 스레드에서 명령어를 사용해야 합니다.",


### PR DESCRIPTION
Adds: button on /threads that allows users with `MANAGE_THREADS`+ to quickly unwatch unknown threads

Fixes: discord.js caching made permissions-check in /threads crash the bot under certain circumstances 