### PR TITLE
Docker and Docker Compose Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This bot includes Docker and Docker Compose support. To build a docker image tha
 To run the resulting docker image, use the following command:
 > docker run --name thread-watcher -d thread-watcher
 
-Alternatively, if you'd prefer to use Docker Compose, you can use the included docker-compose.yml directly by using the following command inside the folder you've cloned the repo:
+Alternatively, if you'd prefer to use Docker Compose, you can use the included `docker-compose.yml` directly by using the following command inside the folder you've cloned the repo:
 > docker-compose up -d
 
 ## License

--- a/README.md
+++ b/README.md
@@ -20,7 +20,14 @@
 </div>
 
 ## Docker
-This bot does currently __not__ come with a docker file. This will be added at a later data.
+This bot includes Docker and Docker Compose support. To build a docker image that will run Thread Watcher upon start (and automatically register the slash commands), use the following command inside the folder you've cloned the repo: 
+> docker build -t thread-watcher bot/
+
+To run the resulting docker image, use the following command:
+> docker run --name thread-watcher -d thread-watcher
+
+Alternatively, if you'd prefer to use Docker Compose, you can use the included docker-compose.yml directly by using the following command inside the folder you've cloned the repo:
+> docker-compose up -d
 
 ## License
 The code for the bot and website are both licensed under the [MIT license](https://github.com/ffamilyfriendly/Thread-Watcher/blob/main/LICENSE.md).

--- a/bot/.dockerignore
+++ b/bot/.dockerignore
@@ -1,0 +1,12 @@
+Dockerfile
+docker*.yml
+.git
+.gitignore
+.config
+.npm
+.vscode
+dist
+node_modules
+npm-debug.log
+LICENSE.md
+README.md

--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -1,0 +1,35 @@
+# Multi-stage build and app-only image
+FROM node:18-slim as builder
+
+# Create the bot's directory
+RUN mkdir -p /usr/src/bot
+
+# Set working directory
+WORKDIR /usr/src/bot
+
+# Copy only the package/tsconfig files and the src dir
+COPY ["package.json", "package-lock.json*", "tsconfig.json", "/usr/src/bot/"]
+COPY ["./src/", "/usr/src/bot/src/"]
+
+# Set NODE_ENV environment variable
+ENV NODE_ENV production
+
+# Install only the necessary packages for build
+RUN npm ci --only=production && npm cache clean --force && npm install -g typescript
+
+# Run the build command which creates the production bundle
+RUN npm run build
+
+COPY . /usr/src/bot
+
+# Create app-only image without including the toolchain 
+FROM node:18-slim as bot
+
+# Copy built node modules and binaries without including the toolchain
+COPY --from=builder /usr/src/bot .
+
+# Don't run container as root
+# USER node
+
+# Start the bot (and register slash commands).
+CMD node ./dist/index.js -reg_commands

--- a/bot/docker-compose.yml
+++ b/bot/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.6"
+services:
+  thread-watcher:
+    container_name: thread-watcher
+    build:
+        context: ./bot
+        dockerfile: Dockerfile
+    restart: always
+    volumes:
+      - type: bind
+        source: ./data/data.db
+        target: /data.db
+
+networks:
+  default:
+    driver: bridge


### PR DESCRIPTION
### Docker
The `Dockerfile` and `.dockerignore` will create a docker image and automatically run the Thread Watcher bot upon start (along with registering the slash commands) when using the following command inside the root folder of the repo:
> docker build -t thread-watcher bot/

To then run the resulting docker image, use the following command:
> docker run --name thread-watcher -d thread-watcher

### Docker Compose
If you'd prefer to use Docker Compose, the included `docker-compose.yml` will build and launch the container by using the following command inside the root folder of the repo:
> docker-compose up -d