### PR TITLE
Changing default config to use SQLite.

### DIFF
--- a/bot/src/_config.ts
+++ b/bot/src/_config.ts
@@ -13,13 +13,17 @@ const config = {
         topgg: ""
     },
     clientID: "592814450084675594",
+    // Thread-Watcher uses sqlite by default, but can support MySQL.
+    // if you wish to use MySQL, you will need to create the "threadwatcher" database and update the parameters in the options section
+    // with the appropriate values. If MySQL is running on the same system, 'host' should be "127.0.01"
     database: {
-        type: DataBases.mysql,
+        type: DataBases.sqlite,
+        // type: DataBases.mysql,
         options: {
-            user: "user",
-            password: "passwd",
-            host: "ip",
-            port: 1337,
+            user: "",
+            password: "",
+            host: "",
+            port: 3306,
             database: "threadwatcher"
         }
     },


### PR DESCRIPTION
Updated the example `_config.ts` to use SQLite by default.

Setting up a MySQL database is more complex and involved, defaulting to SQLite allows for immediate build and launch without additional configuration beyond providing Discord bot and server credentials.

This better aligns with the configuration documentation, which suggests that simply setting `database.type` to "DataBases.sqlite" is the only change needed in the config file. In practice, the default MySQL settings are incompatible with SQLite, and removing the entire options array results in a critical failure of the code.